### PR TITLE
Fix typo in README - add comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 1.  Update your provider configuration:
 
     ```elixir
-    config :ueberauth, Ueberauth.Strategy.Pocket
+    config :ueberauth, Ueberauth.Strategy.Pocket,
       consumer_key: System.get_env("POCKET_CONSUMER_KEY")
     ```
 


### PR DESCRIPTION
Just adding a comma to the README so applications will compile.